### PR TITLE
Fixing Renovate config warnings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,11 +3,6 @@
   "branchPrefix": "renovate/",
   "platform": "github",
   "gitAuthor": "Renovate Bot <renovate-bot@praegus.nl>",
-  "onboarding": true,
-  "dependencyDashboardTitle": "Dependency Dashboard self-hosted",
-  "repositories": [
-    "praegus/MotorsportsManager"
-  ],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
Renovate gives some warnings about misused config properties. Removed these. 